### PR TITLE
fix(tests): use fixture tensor shapes in topk

### DIFF
--- a/.github/workflows/pr-pytest.yml
+++ b/.github/workflows/pr-pytest.yml
@@ -1,0 +1,27 @@
+name: Run Pytest
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  pytest:
+    name: Run pytest via uv
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: uv install
+
+      - name: Run pytest
+        run: uv run pytest

--- a/tests/test_topk.py
+++ b/tests/test_topk.py
@@ -84,7 +84,10 @@ def test_per_layer_topk_has_correct_values(per_layer_topk):
 def test_per_layer_batch_topk_has_correct_values():
     per_layer_batch_topk = PerLayerBatchTopK(k=3, e=0.1, n_layers=2)
     features = torch.tensor(
-        [[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]]
+        [
+            [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]],
+            [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]],
+        ]
     )
     topk_features = per_layer_batch_topk(features)
     # Layer 0: top 6 values from [1,2,3,4,5,11,12,13,14,15] -> keep [11,12,13,14,15,5]
@@ -195,7 +198,9 @@ def test_no_negative_values_in_output(per_layer_topk, per_layer_batch_topk, batc
     assert torch.all(result >= 0), "BatchTopK output contains negative values"
 
 
-def test_mixed_positive_negative_values(per_layer_topk, per_layer_batch_topk, batch_topk):
+def test_mixed_positive_negative_values(
+    per_layer_topk, per_layer_batch_topk, batch_topk
+):
     """Test that topk implementations handle mixed positive/negative values correctly"""
     # Create test tensor with mix of positive and negative values
     mixed_features = torch.tensor(
@@ -224,7 +229,11 @@ def test_mixed_positive_negative_values(per_layer_topk, per_layer_batch_topk, ba
 def nnsight_model():
     import nnsight
 
-    gpt2 = nnsight.LanguageModel("openai-community/gpt2", device_map="auto", dispatch=True)
+    gpt2 = nnsight.LanguageModel(
+        "openai-community/gpt2",
+        device_map="auto",
+        dispatch=True,
+    )
 
     gpt2.requires_grad_(False)
     return gpt2
@@ -234,7 +243,7 @@ def nnsight_model():
     "topk_fixture",
     ["per_layer_topk", "per_layer_batch_topk", "batch_topk"],
 )
-def test_nnsight_compatibility(nnsight_model, topk_fixture, request):
+def test_nnsight_compatibility(nnsight_model, topk_fixture, features, request):
     """Test that all topk implementations work correctly with nnsight tracing"""
     topk = request.getfixturevalue(topk_fixture)
     topk.to(nnsight_model.device)

--- a/tests/test_topk.py
+++ b/tests/test_topk.py
@@ -180,10 +180,13 @@ def test_k_boundary_plus_one_error(features):
         topk(features)
 
 
-def test_no_negative_values_in_output(per_layer_topk, per_layer_batch_topk, batch_topk):
+def test_no_negative_values_in_output(
+    per_layer_topk, per_layer_batch_topk, batch_topk, features
+):
     """Test that all topk implementations never output negative values, even with negative inputs"""
     # Create test tensor with negative values
-    negative_features = torch.randn(2, 3, 4) - 1.0  # Ensures mostly negative values
+
+    negative_features = torch.randn_like(features) - 1.0
 
     # Test PerLayerTopK
     result = per_layer_topk(negative_features)
@@ -199,18 +202,14 @@ def test_no_negative_values_in_output(per_layer_topk, per_layer_batch_topk, batc
 
 
 def test_mixed_positive_negative_values(
-    per_layer_topk, per_layer_batch_topk, batch_topk
+    per_layer_topk,
+    per_layer_batch_topk,
+    batch_topk,
+    features,
 ):
     """Test that topk implementations handle mixed positive/negative values correctly"""
     # Create test tensor with mix of positive and negative values
-    mixed_features = torch.tensor(
-        [
-            [
-                [1.0, -2.0, 3.0, -4.0, 5.0],  # Layer 0: mix of pos/neg
-                [-1.0, 2.0, -3.0, 4.0, -5.0],  # Layer 1: mix of pos/neg
-            ]
-        ]
-    )
+    mixed_features = torch.randn_like(features) - 0.5
 
     # Test PerLayerTopK - should keep top 3 positive values per layer
     result = per_layer_topk(mixed_features)


### PR DESCRIPTION
These changes should fix tests by: 

1. updating fixture use to ensure that tensors passed into `topk` modules fit the same `n_layer` configs that the `topk` modules are parameterized by. 
2. Adds PR workflow to ensure tests change so we can get merging things quickly!